### PR TITLE
On windows, insert path with forward slashes instead of backslashes

### DIFF
--- a/require_helper.py
+++ b/require_helper.py
@@ -1,6 +1,7 @@
 import sublime
 import sublime_plugin
 import os
+import platform
 import re
 import string
 
@@ -34,6 +35,9 @@ class RequireHelperCommand(sublime_plugin.TextCommand):
         if index >= 0:
             insertPos = self.view.sel()[0].begin()
             include = RequireHelperCommand.fileList[index]
+
+            if platform.system() == "Windows":
+                include = include.replace("\\", "/")
 
             if self.fullInsert:
                 include = self.makeFullInsert(include, insertPos)


### PR DESCRIPTION
Example:
Before changes a path would get inserted in the following way:
"collections\links", which is problematic because now the backslash
escapes the next character instead of delimiting a directory.  After the
changes it will get inserted like this: "collections/links".

Note: I’m not a Python programmer, in fact this is the first time I dabbled in the language, so I hope I made this fix in a proper manner. It seems to work though;)
